### PR TITLE
Bug fix on base.html

### DIFF
--- a/mkdocs_bootstrap4/base.html
+++ b/mkdocs_bootstrap4/base.html
@@ -80,7 +80,7 @@
           <span class="navbar-toggler-icon"></span>
 	</button>
 
-	<div class="collapse navbar-collapse">
+	<div class="collapse navbar-collapse" id="navbarsExample04">
 	  {%- block site_nav %}
           {%- if nav|length>1 %}
           <!-- Main navigation -->


### PR DESCRIPTION
Fixed an issue where the menu would not appear because the id attribute referenced by the data-target attribute of navbar-toggler was not set in the navbar-collapse element. Added id="navbarsExample04" to the navbar-collapse element.